### PR TITLE
CS-381 Update python SDK to use new RFCx api for streams

### DIFF
--- a/package-rfcx/rfcx/_api_rfcx.py
+++ b/package-rfcx/rfcx/_api_rfcx.py
@@ -30,8 +30,8 @@ def tags(token, type, labels, start, end, sites, limit):
 # v2 api
 
 # TODO: Add the organizations/projects when the API support
-def streams(token, limit=1000):
-    data = {'limit': limit}
+def streams(token, keyword='', limit=1000, offset=0):
+    data = {'keyword': keyword, 'limit': limit, 'offset': offset}
     path = '/streams'
     url = '{}{}?{}'.format(host, path, urllib.parse.urlencode(data, True))
     return _request(url, token=token)

--- a/package-rfcx/rfcx/_api_rfcx.py
+++ b/package-rfcx/rfcx/_api_rfcx.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 
 host = 'https://api.rfcx.org'  # TODO move to configuration
 
+# v1 api
 def guardians(token, sites):
     data = {'sites[]': sites, 'limit': 1000}
     path = '/v1/guardians'
@@ -25,8 +26,16 @@ def tags(token, type, labels, start, end, sites, limit):
     path = '/v2/tags'
     url = '{}{}?{}'.format(host, path, urllib.parse.urlencode(data, True))
     return _request(url, token=token)
-    
-    
+
+# v2 api
+
+# TODO: Add the organizations/projects when the API support
+def streams(token, limit=1000):
+    data = {'limit': limit}
+    path = '/streams'
+    url = '{}{}?{}'.format(host, path, urllib.parse.urlencode(data, True))
+    return _request(url, token=token)
+
 def _request(url, method='GET', token=None):
     logger.debug('get url: ' + url)
 

--- a/package-rfcx/rfcx/_api_rfcx.py
+++ b/package-rfcx/rfcx/_api_rfcx.py
@@ -21,7 +21,7 @@ def tags(token, type, labels, start, end, sites, limit):
     return _request(url, token=token)
 
 # TODO: Add the organizations/projects when the API support
-def streams(token, keyword='', limit=1000, offset=0):
+def streams(token, keyword=None, limit=1000, offset=0):
     data = {'keyword': keyword, 'limit': limit, 'offset': offset}
     path = '/streams'
     url = '{}{}?{}'.format(host, path, urllib.parse.urlencode(data, True))

--- a/package-rfcx/rfcx/audio.py
+++ b/package-rfcx/rfcx/audio.py
@@ -31,15 +31,15 @@ def __generate_date_in_isoformat(date):
     """ Generate date in iso format ending with `Z` """
     return date.replace(microsecond=0).isoformat() + 'Z'
 
-def save_audio_file(token, dest_path, stream_id, start_time, end_time, gain=1, file_ext='opus'):
+def save_audio_file(token, dest_path, stream_id, start_time, end_time, gain=1, file_ext='wav'):
     """ Prepare `url` and `local_path` and save it using function `__save_file` 
         Args:
             dest_path: Audio save path.
             stream_id: Stream id to get the segment.
             start_time: Minimum timestamp to get the audio.
-            end_time: Maximum timestamp to get the audio.
-            gain: (optional, default = 1) Volumn gain
-            file_ext: (optional, default = '.opus') Extension for saving audio files.
+            end_time: Maximum timestamp to get the audio. (Should not more than 15 min range)
+            gain: (optional, default = 1) Input channel tone loudness
+            file_ext: (optional, default = 'wav') Extension for saving audio files.
 
         Returns:
             None.
@@ -95,7 +95,7 @@ def __segmentDownload(save_path, gain, file_ext, segment, token):
     local_path = __local_audio_file_path(save_path, audio_name, file_ext)
     __save_file(url, local_path, token)
 
-def downloadStreamSegments(token, dest_path, stream_id, min_date, max_date, gain=1, file_ext='opus', parallel=True):
+def downloadStreamSegments(token, dest_path, stream_id, min_date, max_date, gain=1, file_ext='wav', parallel=True):
     """ Download RFCx audio on specific time range using `streamSegments` to get audio segments information
         and save it using function `__save_file`
         Args:
@@ -104,8 +104,8 @@ def downloadStreamSegments(token, dest_path, stream_id, min_date, max_date, gain
             stream_id: RFCx guardian id
             min_date: Download start date
             max_date: Download end date
-            gain: (optional, default= 1) volumn gain.
-            file_ext: (optional, default= '.opus') Extension for saving audio file.
+            gain: (optional, default= 1) Input channel tone loudness
+            file_ext: (optional, default= 'wav') Extension for saving audio file.
             parallel: (optional, default= True) Enable to parallel download audio from RFCx
 
         Returns:

--- a/package-rfcx/rfcx/client.py
+++ b/package-rfcx/rfcx/client.py
@@ -120,6 +120,7 @@ class Client(object):
             f.write(c.token_expiry.isoformat() + 'Z\n')
             f.write(c.id_token + '\n')
 
+    # v1
     def guardians(self, sites=None):
         """Retrieve a list of guardians from a site (TO BE DEPRECATED - use streams in future)
 
@@ -228,3 +229,13 @@ class Client(object):
 
         return audio.downloadGuardianAudio(self.credentials.id_token, dest_path, guardian_id, min_date, max_date, file_ext, parallel)
 
+    # v2
+    def streams(self):
+        """Retrieve a list of streams
+
+        Args:
+
+        Returns:
+            List of streams"""
+
+        return api_rfcx.streams(self.credentials.id_token)

--- a/package-rfcx/rfcx/client.py
+++ b/package-rfcx/rfcx/client.py
@@ -150,15 +150,15 @@ class Client(object):
 
         return api_rfcx.tags(self.credentials.id_token, type, labels, start, end, sites, limit)
 
-    def saveAudioFile(self, dest_path, stream_id, start_time, end_time, gain=1, file_ext='opus'):
+    def saveAudioFile(self, dest_path, stream_id, start_time, end_time, gain=1, file_ext='wav'):
         """ Save audio to local path` 
         Args:
             dest_path: Audio save path.
             stream_id: Stream id to get the segment.
             start_time: Minimum timestamp to get the audio.
-            end_time: Maximum timestamp to get the audio. (Should not more than )
-            gain: (optional, default = 1) Volumn gain
-            file_ext: (optional, default = '.opus') Extension for saving audio files.
+            end_time: Maximum timestamp to get the audio. (Should not more than 15 min range)
+            gain: (optional, default = 1) Input channel tone loudness
+            file_ext: (optional, default = 'wav') Extension for saving audio files.
 
         Returns:
             None.
@@ -206,7 +206,7 @@ class Client(object):
 
         return api_rfcx.streamSegments(self.credentials.id_token, streamId, start, end, limit, offset)
 
-    def downloadStreamSegments(self, dest_path=None, stream_id=None, min_date=None, max_date=None, gain=1, file_ext='opus', parallel=True):
+    def downloadStreamSegments(self, dest_path=None, stream_id=None, min_date=None, max_date=None, gain=1, file_ext='wav', parallel=True):
         """Download audio using audio information from `guardianAudio`
 
         Args:
@@ -214,8 +214,8 @@ class Client(object):
             stream_id: (Required) The guid of a guardian
             min_date: Minimum timestamp of the audio. If None then defaults to exactly 30 days ago.
             max_date: Maximum timestamp of the audio. If None then defaults to now.
-            gain: (optional, default= 1) volumn gain
-            file_ext: (optional, default= '.opus') Audio file extension. Default to `.opus`
+            gain: (optional, default= 1) Input channel tone loudness
+            file_ext: (optional, default= 'wav') Audio file extension. Default to `wav`
             parallel: (optional, default= True) Parallel download audio. Defaults to True.
 
         Returns:
@@ -252,7 +252,7 @@ class Client(object):
 
         return audio.downloadStreamSegments(self.credentials.id_token, dest_path, stream_id, min_date, max_date, gain, file_ext, parallel)
 
-    def streams(self, keyword='', limit=1000, offset=0):
+    def streams(self, keyword=None, limit=1000, offset=0):
         """Retrieve a list of streams
 
         Args:

--- a/package-rfcx/rfcx/client.py
+++ b/package-rfcx/rfcx/client.py
@@ -229,13 +229,15 @@ class Client(object):
 
         return audio.downloadGuardianAudio(self.credentials.id_token, dest_path, guardian_id, min_date, max_date, file_ext, parallel)
 
-    # v2
-    def streams(self):
+    def streams(self, keyword='', limit=1000, offset=0):
         """Retrieve a list of streams
 
         Args:
+            keyword:(optional, default= '') Match streams with name
+            limit: (optional, default= 1000) Maximum number of  results to return
+            offset: (optional, default= 0) Number of results to skip
 
         Returns:
             List of streams"""
 
-        return api_rfcx.streams(self.credentials.id_token)
+        return api_rfcx.streams(self.credentials.id_token, keyword, limit, offset)


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves CS-381

## 📝 Summary

- Add the new streams API endpoint to the SDK for getting streams list

## 🛑 Problems

- The new streams endpoint still not support getting the streams by giving the projects/organizations ids

## 💡 More ideas

- Update the new core API to support streams query by projects/organizations id
