### PR TITLE
CS-380 Update python SDK to use new RFCx api for audio

### DIFF
--- a/package-rfcx/rfcx/_api_rfcx.py
+++ b/package-rfcx/rfcx/_api_rfcx.py
@@ -25,8 +25,14 @@ def tags(token, type, labels, start, end, sites, limit):
     path = '/v2/tags'
     url = '{}{}?{}'.format(host, path, urllib.parse.urlencode(data, True))
     return _request(url, token=token)
-    
-    
+
+# v2
+def streamAudio(token, stream_id, start, end, limit, offset):
+    data = {'id': stream_id, 'start': start, 'end': end, 'limit': limit, 'offset': offset}
+    path = f'/streams/{stream_id}/stream-segments'
+    url = '{}{}?{}'.format(host, path, urllib.parse.urlencode(data, True))
+    return _request(url, token=token)
+
 def _request(url, method='GET', token=None):
     logger.debug('get url: ' + url)
 

--- a/package-rfcx/rfcx/_api_rfcx.py
+++ b/package-rfcx/rfcx/_api_rfcx.py
@@ -8,25 +8,12 @@ logger = logging.getLogger(__name__)
 
 host = 'https://api.rfcx.org'  # TODO move to configuration
 
-def guardians(token, sites):
-    data = {'sites[]': sites, 'limit': 1000}
-    path = '/v1/guardians'
-    url = '{}{}?{}'.format(host, path, urllib.parse.urlencode(data, True))
-    return _request(url, token=token)
-
-def guardianAudio(token, guardianId, start, end, limit, offset=0, descending=True):
-    data = {'starting_after': start, 'ending_before': end, 'limit': limit, 'offset': offset, 'order': 'descending' if descending else 'ascending'}
-    path = f'/v1/guardians/{guardianId}/audio'
-    url = '{}{}?{}'.format(host, path, urllib.parse.urlencode(data, True))
-    return _request(url, token=token)
-
 def tags(token, type, labels, start, end, sites, limit):
     data = {'type': type, 'values[]': labels, 'starting_after_local': start, 'starting_before_local': end, 'sites[]': sites, 'limit': limit}
     path = '/v2/tags'
     url = '{}{}?{}'.format(host, path, urllib.parse.urlencode(data, True))
     return _request(url, token=token)
 
-# v2
 def streamSegments(token, stream_id, start, end, limit, offset):
     data = {'id': stream_id, 'start': start, 'end': end, 'limit': limit, 'offset': offset}
     path = f'/streams/{stream_id}/stream-segments'

--- a/package-rfcx/rfcx/_api_rfcx.py
+++ b/package-rfcx/rfcx/_api_rfcx.py
@@ -27,7 +27,7 @@ def tags(token, type, labels, start, end, sites, limit):
     return _request(url, token=token)
 
 # v2
-def streamAudio(token, stream_id, start, end, limit, offset):
+def streamSegments(token, stream_id, start, end, limit, offset):
     data = {'id': stream_id, 'start': start, 'end': end, 'limit': limit, 'offset': offset}
     path = f'/streams/{stream_id}/stream-segments'
     url = '{}{}?{}'.format(host, path, urllib.parse.urlencode(data, True))

--- a/package-rfcx/rfcx/audio.py
+++ b/package-rfcx/rfcx/audio.py
@@ -19,7 +19,9 @@ def __save_file(url, local_path, token):
             shutil.copyfileobj(response.raw, out_file)
             print('Saved {}'.format(local_path))
     else:
-        print("Can not download {} with status {}".format(url, response.status_code))
+        print("Can not download", url)
+        reason = response.json()
+        print("Reason:", response.status_code, reason["message"])
 
 def __local_audio_file_path(path, audio_name, audio_extension):
     """ Create string for the name and the path """    
@@ -32,9 +34,12 @@ def __generate_date_in_isoformat(date):
 def save_audio_file(token, dest_path, stream_id, start_time, end_time, gain=1, file_ext='opus'):
     """ Prepare `url` and `local_path` and save it using function `__save_file` 
         Args:
-            destination_path: Audio save path.
-            audio_id: RFCx audio id in format `{stream_id}_t{start time}.{end time}_g{audio gain}_f{audio format}`
-            source_audio_extension: (optional, default= '.opus') Extension for saving audio files.
+            dest_path: Audio save path.
+            stream_id: Stream id to get the segment.
+            start_time: Minimum timestamp to get the audio.
+            end_time: Maximum timestamp to get the audio.
+            gain: (optional, default = 1) Volumn gain
+            file_ext: (optional, default = '.opus') Extension for saving audio files.
 
         Returns:
             None.

--- a/package-rfcx/rfcx/audio.py
+++ b/package-rfcx/rfcx/audio.py
@@ -55,7 +55,7 @@ def save_audio_file(token, dest_path, stream_id, start_time, end_time, gain=1, f
                                                                                     end_time=end,
                                                                                     gain=gain,
                                                                                     file_ext=file_ext)
-    url = "https://api.rfcx.org/internal/assets/streams/" + audio_name + "." + file_ext
+    url = "https://media-api.rfcx.org/internal/assets/streams/" + audio_name + "." + file_ext
     local_path = __local_audio_file_path(dest_path, audio_name, file_ext)
     __save_file(url, local_path, token)
 
@@ -91,7 +91,7 @@ def __segmentDownload(save_path, gain, file_ext, segment, token):
                                                                                                 gain=gain,
                                                                                                 file_ext=file_ext)
     audio_name = "{}_{}_{}_gain{}".format(stream_id, start, segment['id'], gain)
-    url = "https://api.rfcx.org/internal/assets/streams/" + rfcx_audio_format + "." + file_ext
+    url = "https://media-api.rfcx.org/internal/assets/streams/" + rfcx_audio_format + "." + file_ext
     local_path = __local_audio_file_path(save_path, audio_name, file_ext)
     __save_file(url, local_path, token)
 

--- a/package-rfcx/rfcx/audio.py
+++ b/package-rfcx/rfcx/audio.py
@@ -3,26 +3,21 @@ import requests
 import shutil
 import os
 import concurrent.futures
-from rfcx._api_rfcx import guardianAudio, streamSegments
+from rfcx._api_rfcx import streamSegments
 
-# v1
-def __save_file(url, local_path, token=None):
+def __save_file(url, local_path, token):
     """ Download the file from `url` and save it locally under `local_path` """
-    #  TODO: Duplicate non token authen download for v1 api
-    response = {}
-    if (token != None):
-        headers = {
-            "Authorization": "Bearer " + token,
-            'Content-Type': 'application/json'
-        }
-        response = requests.get(url, headers=headers, stream=True)
-    else:
-        response = requests.get(url, stream=True)
+    headers = {
+        "Authorization": "Bearer " + token,
+        'Content-Type': 'application/json'
+    }
+    response = requests.get(url, headers=headers, stream=True)
 
     if (response.status_code == 200):
         with open(local_path, 'wb') as out_file:
             response.raw.decode_content = True
             shutil.copyfileobj(response.raw, out_file)
+            print('Saved {}'.format(local_path))
     else:
         print("Can not download {} with status {}".format(url, response.status_code))
 
@@ -30,98 +25,11 @@ def __local_audio_file_path(path, audio_name, audio_extension):
     """ Create string for the name and the path """    
     return path + '/' + audio_name + "." + audio_extension
 
-def save_audio_file(destination_path, audio_id, source_audio_extension='opus'):
-    """ Prepare `url` and `local_path` and save it using function `__save_file` (TO BE DEPRECATED - use save_audio_file2 in future)
-        Args:
-            destination_path: Audio save path.
-            audio_id: RFCx audio id.
-            source_audio_extension: (optional, default= '.opus') Extension for saving audio files.
-
-        Returns:
-            None.
-
-        Raises:
-            TypeError: if missing required arguements.
-    
-    """
-    url = "https://assets.rfcx.org/audio/" + audio_id + "." + source_audio_extension
-    local_path = __local_audio_file_path(destination_path, audio_id, source_audio_extension)
-    __save_file(url, local_path)
-    print('File {}.{} saved to {}'.format(audio_id, source_audio_extension, destination_path))
-
 def __generate_date_in_isoformat(date):
     """ Generate date in iso format ending with `Z` """
     return date.replace(microsecond=0).isoformat() + 'Z'
 
-def __get_all_segments(token, guardian_id, start, end):
-    all_segments = []
-    empty_segment = False
-    offset = 0
-
-    while not empty_segment:
-        # No data will return `None` from server
-        segments = guardianAudio(token, guardian_id, start, end, limit=1000, offset=offset, descending=False)
-        if segments:
-            all_segments.extend(segments)
-            offset = offset + 1000
-        else:
-            empty_segment = True
-
-    return all_segments
-
-def __segmentDownload(audio_path, file_ext, segment):
-    audio_id = segment['guid']
-    audio_name = "{}_{}_{}".format(segment['guardian_guid'], segment['measured_at'].replace(':', '-').replace('.', '-'), audio_id)
-    url = "https://assets.rfcx.org/audio/" + audio_id + "." + file_ext
-    local_path = __local_audio_file_path(audio_path, audio_name, file_ext)
-    __save_file(url, local_path)
-
-def downloadGuardianAudio(token, destination_path, guardian_id, min_date, max_date, file_ext='opus', parallel=True):
-    """ Download RFCx audio on specific time range using `guardianAudio` to get audio segments information (TO BE DEPRECATED - use downloadStreamSegments in future)
-        and save it using function `__save_file`
-        Args:
-            token: RFCx client token.
-            destination_path: Audio save path.
-            guardian_id: RFCx guardian id
-            min_date: Download start date
-            max_date: Download end date
-            file_ext: (optional, default= '.opus') Extension for saving audio file.
-            parallel: (optional, default= True) Enable to parallel download audio from RFCx
-
-        Returns:
-            None.
-
-        Raises:
-            TypeError: if missing required arguements.
-    
-    """
-    audio_path = destination_path + '/' + guardian_id
-    if not os.path.exists(audio_path):
-        os.makedirs(audio_path)
-
-    start = __generate_date_in_isoformat(min_date)
-    end = __generate_date_in_isoformat(max_date)
-
-    segments = __get_all_segments(token, guardian_id, start, end)
-
-    if segments:
-        print("Downloading {} audio from {}".format(len(segments), guardian_id))
-        if(parallel):
-            with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
-                futures = []
-                for segment in segments:
-                    futures.append(executor.submit(__segmentDownload, audio_path=audio_path, file_ext=file_ext, segment=segment))
-
-                futures, _ = concurrent.futures.wait(futures)
-        else:
-            for segment in segments:
-                __segmentDownload(audio_path, file_ext, segment)
-        print("Finish download on {}".format(guardian_id))
-    else:
-        print("No data found on {} - {} at {}".format(start[:-10], end[:-10], guardian_id))
-
-# v2
-def save_audio_file2(token, destination_path, audio_id, source_audio_extension='opus'):
+def save_audio_file(token, dest_path, stream_id, start_time, end_time, gain=1, file_ext='opus'):
     """ Prepare `url` and `local_path` and save it using function `__save_file` 
         Args:
             destination_path: Audio save path.
@@ -135,16 +43,22 @@ def save_audio_file2(token, destination_path, audio_id, source_audio_extension='
             TypeError: if missing required arguements.
     
     """
-    url = "https://api.rfcx.org/internal/assets/streams/" + audio_id + "." + source_audio_extension
-    local_path = __local_audio_file_path(destination_path, audio_id, source_audio_extension)
+    start = iso_to_rfcx_custom_format(__generate_date_in_isoformat(start_time))
+    end = iso_to_rfcx_custom_format(__generate_date_in_isoformat(end_time))
+    audio_name = "{stream_id}_t{start_time}.{end_time}_g{gain}_f{file_ext}".format(stream_id=stream_id,
+                                                                                    start_time=start,
+                                                                                    end_time=end,
+                                                                                    gain=gain,
+                                                                                    file_ext=file_ext)
+    url = "https://api.rfcx.org/internal/assets/streams/" + audio_name + "." + file_ext
+    local_path = __local_audio_file_path(dest_path, audio_name, file_ext)
     __save_file(url, local_path, token)
-    print('File {}.{} saved to {}'.format(audio_id, source_audio_extension, destination_path))
 
 def iso_to_rfcx_custom_format(time):
     """Convert RFCx iso format to RFCx custom format"""
     return time.replace('-', '').replace(':', '').replace('.', '')
 
-def __get_all_segments2(token, stream_id, start, end):
+def __get_all_segments(token, stream_id, start, end):
     """Get all audio segment in the `start` and `end` time range"""
     all_segments = []
     empty_segment = False
@@ -161,7 +75,7 @@ def __get_all_segments2(token, stream_id, start, end):
 
     return all_segments
 
-def __segmentDownload2(save_path, gain, file_ext, segment, token):
+def __segmentDownload(save_path, gain, file_ext, segment, token):
     """Download audio using the core api(v2)"""
     stream_id = segment['stream']['id']
     start = iso_to_rfcx_custom_format(segment['start'])
@@ -202,7 +116,7 @@ def downloadStreamSegments(token, dest_path, stream_id, min_date, max_date, gain
     start = __generate_date_in_isoformat(min_date)
     end = __generate_date_in_isoformat(max_date)
 
-    segments = __get_all_segments2(token, stream_id, start, end)
+    segments = __get_all_segments(token, stream_id, start, end)
 
     if segments:
         print("Downloading {} audio from {}".format(len(segments), stream_id))
@@ -210,12 +124,12 @@ def downloadStreamSegments(token, dest_path, stream_id, min_date, max_date, gain
             with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
                 futures = []
                 for segment in segments:
-                    futures.append(executor.submit(__segmentDownload2, save_path, gain, file_ext, segment, token))
+                    futures.append(executor.submit(__segmentDownload, save_path, gain, file_ext, segment, token))
 
                 futures, _ = concurrent.futures.wait(futures)
         else:
             for segment in segments:
-                __segmentDownload2(save_path, gain, file_ext, segment, token)
+                __segmentDownload(save_path, gain, file_ext, segment, token)
         print("Finish download on {}".format(stream_id))
     else:
         print("No data found on {} - {} at {}".format(start[:-10], end[:-10], stream_id))

--- a/package-rfcx/rfcx/audio.py
+++ b/package-rfcx/rfcx/audio.py
@@ -3,7 +3,7 @@ import requests
 import shutil
 import os
 import concurrent.futures
-from rfcx._api_rfcx import guardianAudio, streamAudio
+from rfcx._api_rfcx import guardianAudio, streamSegments
 
 # v1
 def __save_file(url, local_path, token=None):
@@ -77,7 +77,7 @@ def __segmentDownload(audio_path, file_ext, segment):
     __save_file(url, local_path)
 
 def downloadGuardianAudio(token, destination_path, guardian_id, min_date, max_date, file_ext='opus', parallel=True):
-    """ Download RFCx audio on specific time range using `guardianAudio` to get audio segments information (TO BE DEPRECATED - use downloadStreamAudio in future)
+    """ Download RFCx audio on specific time range using `guardianAudio` to get audio segments information (TO BE DEPRECATED - use downloadStreamSegments in future)
         and save it using function `__save_file`
         Args:
             token: RFCx client token.
@@ -152,7 +152,7 @@ def __get_all_segments2(token, stream_id, start, end):
 
     while not empty_segment:
         # No data will return empty array from server
-        segments = streamAudio(token, stream_id, start, end, limit=1000, offset=offset)
+        segments = streamSegments(token, stream_id, start, end, limit=1000, offset=offset)
         if segments:
             all_segments.extend(segments)
             offset = offset + 1000
@@ -176,8 +176,8 @@ def __segmentDownload2(save_path, gain, file_ext, segment, token):
     local_path = __local_audio_file_path(save_path, audio_name, file_ext)
     __save_file(url, local_path, token)
 
-def downloadStreamAudio(token, dest_path, stream_id, min_date, max_date, gain=1, file_ext='opus', parallel=True):
-    """ Download RFCx audio on specific time range using `streamAudio` to get audio segments information
+def downloadStreamSegments(token, dest_path, stream_id, min_date, max_date, gain=1, file_ext='opus', parallel=True):
+    """ Download RFCx audio on specific time range using `streamSegments` to get audio segments information
         and save it using function `__save_file`
         Args:
             token: RFCx client token.

--- a/package-rfcx/rfcx/audio.py
+++ b/package-rfcx/rfcx/audio.py
@@ -3,11 +3,22 @@ import requests
 import shutil
 import os
 import concurrent.futures
-from rfcx._api_rfcx import guardianAudio
+from rfcx._api_rfcx import guardianAudio, streamAudio
 
-def __save_file(url, local_path):
+# v1
+def __save_file(url, local_path, token=None):
     """ Download the file from `url` and save it locally under `local_path` """
-    response = requests.get(url, stream=True)
+    #  TODO: Duplicate non token authen download for v1 api
+    response = {}
+    if (token != None):
+        headers = {
+            "Authorization": "Bearer " + token,
+            'Content-Type': 'application/json'
+        }
+        response = requests.get(url, headers=headers, stream=True)
+    else:
+        response = requests.get(url, stream=True)
+
     if (response.status_code == 200):
         with open(local_path, 'wb') as out_file:
             response.raw.decode_content = True
@@ -20,7 +31,7 @@ def __local_audio_file_path(path, audio_name, audio_extension):
     return path + '/' + audio_name + "." + audio_extension
 
 def save_audio_file(destination_path, audio_id, source_audio_extension='opus'):
-    """ Prepare `url` and `local_path` and save it using function `__save_file` 
+    """ Prepare `url` and `local_path` and save it using function `__save_file` (TO BE DEPRECATED - use save_audio_file2 in future)
         Args:
             destination_path: Audio save path.
             audio_id: RFCx audio id.
@@ -66,7 +77,7 @@ def __segmentDownload(audio_path, file_ext, segment):
     __save_file(url, local_path)
 
 def downloadGuardianAudio(token, destination_path, guardian_id, min_date, max_date, file_ext='opus', parallel=True):
-    """ Download RFCx audio on specific time range using `guardianAudio` to get audio segments information
+    """ Download RFCx audio on specific time range using `guardianAudio` to get audio segments information (TO BE DEPRECATED - use downloadStreamAudio in future)
         and save it using function `__save_file`
         Args:
             token: RFCx client token.
@@ -108,3 +119,103 @@ def downloadGuardianAudio(token, destination_path, guardian_id, min_date, max_da
         print("Finish download on {}".format(guardian_id))
     else:
         print("No data found on {} - {} at {}".format(start[:-10], end[:-10], guardian_id))
+
+# v2
+def save_audio_file2(token, destination_path, audio_id, source_audio_extension='opus'):
+    """ Prepare `url` and `local_path` and save it using function `__save_file` 
+        Args:
+            destination_path: Audio save path.
+            audio_id: RFCx audio id in format `{stream_id}_t{start time}.{end time}_g{audio gain}_f{audio format}`
+            source_audio_extension: (optional, default= '.opus') Extension for saving audio files.
+
+        Returns:
+            None.
+
+        Raises:
+            TypeError: if missing required arguements.
+    
+    """
+    url = "https://api.rfcx.org/internal/assets/streams/" + audio_id + "." + source_audio_extension
+    local_path = __local_audio_file_path(destination_path, audio_id, source_audio_extension)
+    __save_file(url, local_path, token)
+    print('File {}.{} saved to {}'.format(audio_id, source_audio_extension, destination_path))
+
+def iso_to_rfcx_custom_format(time):
+    """Convert RFCx iso format to RFCx custom format"""
+    return time.replace('-', '').replace(':', '').replace('.', '')
+
+def __get_all_segments2(token, stream_id, start, end):
+    """Get all audio segment in the `start` and `end` time range"""
+    all_segments = []
+    empty_segment = False
+    offset = 0
+
+    while not empty_segment:
+        # No data will return empty array from server
+        segments = streamAudio(token, stream_id, start, end, limit=1000, offset=offset)
+        if segments:
+            all_segments.extend(segments)
+            offset = offset + 1000
+        else:
+            empty_segment = True
+
+    return all_segments
+
+def __segmentDownload2(save_path, gain, file_ext, segment, token):
+    """Download audio using the core api(v2)"""
+    stream_id = segment['stream']['id']
+    start = iso_to_rfcx_custom_format(segment['start'])
+    end = iso_to_rfcx_custom_format(segment['end'])
+    custom_time_range = start + '.' + end
+    rfcx_audio_format = "{stream_id}_t{time}_rfull_g{gain}_f{file_ext}".format(stream_id=stream_id,
+                                                                                                time=custom_time_range,
+                                                                                                gain=gain,
+                                                                                                file_ext=file_ext)
+    audio_name = "{}_{}_{}_gain{}".format(stream_id, start, segment['id'], gain)
+    url = "https://api.rfcx.org/internal/assets/streams/" + rfcx_audio_format + "." + file_ext
+    local_path = __local_audio_file_path(save_path, audio_name, file_ext)
+    __save_file(url, local_path, token)
+
+def downloadStreamAudio(token, dest_path, stream_id, min_date, max_date, gain=1, file_ext='opus', parallel=True):
+    """ Download RFCx audio on specific time range using `streamAudio` to get audio segments information
+        and save it using function `__save_file`
+        Args:
+            token: RFCx client token.
+            dest_path: Audio save path.
+            stream_id: RFCx guardian id
+            min_date: Download start date
+            max_date: Download end date
+            gain: (optional, default= 1) volumn gain.
+            file_ext: (optional, default= '.opus') Extension for saving audio file.
+            parallel: (optional, default= True) Enable to parallel download audio from RFCx
+
+        Returns:
+            None.
+
+        Raises:
+            TypeError: if missing required arguements.
+    """
+    save_path = dest_path + '/' + stream_id
+    if not os.path.exists(save_path):
+        os.makedirs(save_path)
+
+    start = __generate_date_in_isoformat(min_date)
+    end = __generate_date_in_isoformat(max_date)
+
+    segments = __get_all_segments2(token, stream_id, start, end)
+
+    if segments:
+        print("Downloading {} audio from {}".format(len(segments), stream_id))
+        if(parallel):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
+                futures = []
+                for segment in segments:
+                    futures.append(executor.submit(__segmentDownload2, save_path, gain, file_ext, segment, token))
+
+                futures, _ = concurrent.futures.wait(futures)
+        else:
+            for segment in segments:
+                __segmentDownload2(save_path, gain, file_ext, segment, token)
+        print("Finish download on {}".format(stream_id))
+    else:
+        print("No data found on {} - {} at {}".format(start[:-10], end[:-10], stream_id))

--- a/package-rfcx/rfcx/client.py
+++ b/package-rfcx/rfcx/client.py
@@ -151,12 +151,12 @@ class Client(object):
         return api_rfcx.tags(self.credentials.id_token, type, labels, start, end, sites, limit)
 
     def saveAudioFile(self, dest_path, stream_id, start_time, end_time, gain=1, file_ext='opus'):
-        """ Save audio to f` 
+        """ Save audio to local path` 
         Args:
             dest_path: Audio save path.
             stream_id: Stream id to get the segment.
             start_time: Minimum timestamp to get the audio.
-            end_time: Maximum timestamp to get the audio.
+            end_time: Maximum timestamp to get the audio. (Should not more than )
             gain: (optional, default = 1) Volumn gain
             file_ext: (optional, default = '.opus') Extension for saving audio files.
 

--- a/package-rfcx/rfcx/client.py
+++ b/package-rfcx/rfcx/client.py
@@ -246,7 +246,7 @@ class Client(object):
         """
         return audio.save_audio_file2(self.credentials.id_token, dest, audio_id, file_ext)
 
-    def streamAudio(self, streamId, start, end, limit=50, offset=0):
+    def streamSegments(self, streamId, start, end, limit=50, offset=0):
         """Retrieve audio information about a specific stream
 
         Args:
@@ -273,9 +273,9 @@ class Client(object):
         if end == None:
             end = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + 'Z'
 
-        return api_rfcx.streamAudio(self.credentials.id_token, streamId, start, end, limit, offset)
+        return api_rfcx.streamSegments(self.credentials.id_token, streamId, start, end, limit, offset)
 
-    def downloadStreamAudio(self, dest_path=None, stream_id=None, min_date=None, max_date=None, gain=1, file_ext='opus', parallel=True):
+    def downloadStreamSegments(self, dest_path=None, stream_id=None, min_date=None, max_date=None, gain=1, file_ext='opus', parallel=True):
         """Download audio using audio information from `guardianAudio`
 
         Args:
@@ -295,7 +295,7 @@ class Client(object):
             return
 
         if stream_id == None:
-            print("Please specific the guardian id.")
+            print("Please specific the stream id.")
             return
 
         if min_date == None:
@@ -319,4 +319,4 @@ class Client(object):
                 print('`audios` directory is already exits. Please specific the directory to save audio path or remove `audios` directoy')
                 return
 
-        return audio.downloadStreamAudio(self.credentials.id_token, dest_path, stream_id, min_date, max_date, gain, file_ext, parallel)
+        return audio.downloadStreamSegments(self.credentials.id_token, dest_path, stream_id, min_date, max_date, gain, file_ext, parallel)

--- a/package-rfcx/setup.py
+++ b/package-rfcx/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 REQUIRED_PACKAGES = ['httplib2', 'six']
 
 setup(name='rfcx',
-      version='0.0.10',
+      version='0.0.11',
       url='https://github.com/rfcx/rfcx-sdk-python',
       license='None',
       author='Rainforest Connection',


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves CS-380

## 📝 Summary

- Update the API to get audio from new endpoint (`/stream`)
- Delete audio function for API v1
- Support download parallel
- Support download individual

## 🛑 Problems

- The new API require authentication on all calling method

## 💡 More ideas

- Migrate API v1 in the future version 
- Need to upgrade other function to support authentication 
