### PR TITLE
Add docs, and change example

### DIFF
--- a/docs/rfcx/client.html
+++ b/docs/rfcx/client.html
@@ -326,7 +326,7 @@ created_by_id, created_at, updated_at, created_by, and country_name as default.<
 <dt><strong><code>version</code></strong></dt>
 <dd>(required) Classifier version</dd>
 <dt><strong><code>classification_values</code></strong></dt>
-<dd>(required) List of mappings from model class name to classification values</dd>
+<dd>(required) List of mappings from model class name to classification values to ignore threshold (from_model_class_name[:to_classification_value][:ignore_threshold])</dd>
 </dl>
 <h2 id="returns">Returns</h2>
 <p>Identifier for created classifier (int)</p></div>

--- a/package-rfcx/example-classifier.py
+++ b/package-rfcx/example-classifier.py
@@ -17,11 +17,11 @@ for i, classification in enumerate(possible_classifications):
 # classification_values = [c['value'] for c in classifications]
 # print(f'Selected classification values: {",".join(classification_values)}')
 classification_values = [
-    # model_output_class:rfcx_classification_value
-    'Sciurus_carolinensis_simple_call:sciurus_carolinensis_simple_call_1',
-    'Sciurus_carolinensis_simple_call_2:sciurus_carolinensis_simple_call_2', 
-    'Sciurus_vulgaris_simple_call:sciurus_vulgaris_simple_call_1', 
-    'Sciurus_vulgaris_simple_call_2:sciurus_vulgaris_simple_call_2']
+    # model_output_class[:rfcx_classification_value][:ignore_threshold]
+    'Sciurus_carolinensis_simple_call:sciurus_carolinensis_simple_call_1:0.4',
+    'Sciurus_carolinensis_simple_call_2:sciurus_carolinensis_simple_call_2:0.2', 
+    'Sciurus_vulgaris_simple_call:sciurus_vulgaris_simple_call_1:1.0', 
+    'Sciurus_vulgaris_simple_call_2:sciurus_vulgaris_simple_call_2:0.1']
 
 # Upload the model
 filepath = 'squirrel.tar.gz'

--- a/package-rfcx/rfcx/client.py
+++ b/package-rfcx/rfcx/client.py
@@ -343,7 +343,7 @@ class Client(object):
             filepath: (required) Path of the local file (tar.gz) containing the model (currently only supports RFCx's tf2 format)
             name: (required) Classifier name
             version: (required) Classifier version
-            classification_values: (required) List of mappings from model class name to classification values
+            classification_values: (required) List of mappings from model class name to classification values to ignore threshold (from_model_class_name[:to_classification_value][:ignore_threshold])
 
         Returns:
             Identifier for created classifier (int)


### PR DESCRIPTION
according to this rfcx/rfcx-api#529

- the doc generated from command
- I didn't test `example-classifier.py` but it should work since the format is correct.
![Screenshot 2567-01-16 at 16 02 05](https://github.com/rfcx/rfcx-sdk-python/assets/44440424/8892e8f2-5942-42c5-a7ac-c28a5bbd15de)
